### PR TITLE
Add Open Graph image support and robots meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -108,6 +108,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <meta property="og:image" content={ogImage} />
+      <meta name="robots" content="noindex, nofollow" />
       <body className={leagueScript.variable}>
         <AppRouterCacheProvider>
           <ThemeWrapper sanityTheme={sanityTheme}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,7 @@ import { Prata } from "next/font/google"
 import { draftMode } from "next/headers"
 import "./globals.css"
 import { getUserInviteCookie } from "@/server/cookies"
+import { imageLoader } from "@/sanity"
 
 const leagueScript = Prata({
   weight: ["400"],
@@ -42,6 +43,9 @@ export default async function RootLayout({
   const sanityTheme = await getSanityTheme()
   const sanitySettings = await getSettings()
   const pageNames = sanitySettings?.pageNames
+  const ogImage = imageLoader({
+    source: sanitySettings?.images?.ogImage?.asset,
+  })
   const showNav = Boolean(process.env.NEXT_MAIN_SITE_FLAG)
 
   const inviteCookie = await getUserInviteCookie()
@@ -103,6 +107,7 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
+      <meta property="og:image" content={ogImage} />
       <body className={leagueScript.variable}>
         <AppRouterCacheProvider>
           <ThemeWrapper sanityTheme={sanityTheme}>

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -221,6 +221,17 @@ export type Settings = {
     registry?: string
   }
   images?: {
+    ogImage?: {
+      asset?: {
+        _ref: string
+        _type: "reference"
+        _weak?: boolean
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset"
+      }
+      hotspot?: SanityImageHotspot
+      crop?: SanityImageCrop
+      _type: "image"
+    }
     thankYou?: {
       asset?: {
         _ref: string


### PR DESCRIPTION
Introduce Open Graph image support in the layout and extend the Settings type to include an ogImage property. Add a robots meta tag to prevent indexing and following of the page.