### PR TITLE
Enhance SEO and social sharing with meta tags for wedding website

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -107,8 +107,33 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
-      <meta property="og:image" content={ogImage} />
       <meta name="robots" content="noindex, nofollow" />
+      <title>L+B Wedding</title>
+      <meta
+        name="description"
+        content="Luke and Bernadette's wedding website"
+      />
+
+      {/* <!-- Facebook Meta Tags --> */}
+      <meta property="og:url" content="https://www.beach-wedding.org" />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content="L+B Wedding" />
+      <meta
+        property="og:description"
+        content="Luke and Bernadette's wedding website"
+      />
+      <meta property="og:image" content={ogImage} />
+
+      {/* <!-- Twitter Meta Tags --> */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta property="twitter:domain" content="beach-wedding.org" />
+      <meta property="twitter:url" content="https://www.beach-wedding.org" />
+      <meta name="twitter:title" content="L+B Wedding" />
+      <meta
+        name="twitter:description"
+        content="Luke and Bernadette's wedding website"
+      />
+      <meta name="twitter:image" content={ogImage} />
       <body className={leagueScript.variable}>
         <AppRouterCacheProvider>
           <ThemeWrapper sanityTheme={sanityTheme}>


### PR DESCRIPTION
Add meta tags to improve SEO and enable better social sharing for the wedding website. This includes Open Graph and Twitter Card tags for enhanced visibility.